### PR TITLE
Update octopus pallets to latest v0.9.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4200,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-appchain"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#5c9dbf4ab617f2b0655ab0a9a94f7fca9578c975"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#51ed694034b57c73ebb177502470df602140ddad"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -4224,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-lpos"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#5c9dbf4ab617f2b0655ab0a9a94f7fca9578c975"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#51ed694034b57c73ebb177502470df602140ddad"
 dependencies = [
  "borsh",
  "frame-benchmarking",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-support"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#5c9dbf4ab617f2b0655ab0a9a94f7fca9578c975"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#51ed694034b57c73ebb177502470df602140ddad"
 dependencies = [
  "borsh",
  "frame-support",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "pallet-octopus-upward-messages"
 version = "4.0.0-pre.0"
-source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#5c9dbf4ab617f2b0655ab0a9a94f7fca9578c975"
+source = "git+https://github.com/octopus-network/octopus-pallets.git?branch=release-v0.9.12#51ed694034b57c73ebb177502470df602140ddad"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7799,9 +7799,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "twox-hash"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
+checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand 0.8.4",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -158,7 +158,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 103,
+	spec_version: 104,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
# Title

- [ ] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [ ] Is your title relatable to the JIRA issue?
- [ ] Title <= 100 characters

# Description

Please include a summary of the change in dot point form. Please also include relevant motivation for decisions you made and if there are any TODO items you could not complete. List any dependencies that you added (e.g. package.json).

For example:

- Filename.js: Added comment button to CommentComponent
  - I only enabled the button if the user has logged in (motivation)
  - I couldn't figure out a way to centre the button with flexbox (TODO)
- Filename2.js: bla bla bla
  - nocus dorem iptus locum
- package.json:
  - Added sharp version 2.1.0
    - Need this to compress images (motivation)
    - Tried compress-js but it's deprecated (more motivation)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Builds and runs on Windows
- [ ] Builds and runs on MacOS
- [ ] Builds and runs on Linux
- [ ] Builds and runs on Docker (Linux)
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Have you added yourself as the Assignee?
- [ ] Have you added 1 or more leads as the Reviewer?
- [ ] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
